### PR TITLE
Stats adjustment for player overhead and minor cleanup

### DIFF
--- a/README-ELV.md
+++ b/README-ELV.md
@@ -4,12 +4,18 @@
 
 ## Dependencies - Mac OSX
 
-  `brew install lua@5.1`  # Will work without when using --disable-lua
+  `brew install lua@5.1`
   `brew install youtube-dl`
 
 ## Dependencies - Ubuntu
 
-  Nothing special on 18.04
+  ` apt install \
+      lua5.1 \
+      luajit \
+      liblua5.1-dev \
+      libluajit-5.1-dev \
+      youtube-dl
+  `
 
 ## Configure and build
 

--- a/common/stats.h
+++ b/common/stats.h
@@ -89,8 +89,15 @@ struct stats {
     long long first_seg_open_usec; // this becomes t1
     long long first_buf_read_usec;
     long long first_packet_decode_usec; // this becomes t2
+
     struct packetstats packetstats_video[1000 * 1000]; // packets are actually "frames" in video; nothing to do with network
     struct packetstats packetstats_audio[1000 * 1000];
+
+    /*
+     * MPV initializes its DASH subsystem after receiving the manifest which takes a long time (around 3 sec)
+     * Player overhead = time to open first init segment - time manifest received
+     */
+    long long player_overhead;
 };
 
 extern struct stats *gst;


### PR DESCRIPTION
- add 'legend' to the logs explaining what the numbers mean
- change ELVTRC to ELVSTATS for the final stats so they can be grep'd out easily
- add segment ttfb and tt relative to self
- adjust latency for player overhead
- add Ubuntur instructions to README-ELV.md
